### PR TITLE
feat: API-330: Updated rule ntur-rfc-9457-content-type to handle …

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -270,12 +270,12 @@ rules:
   entur-rfc-9457-content-type:
     message: "Error responses MUST have content type application/problem+json."
     severity: error
-    given: $.paths.*.*.responses[?(@property.match(/^(4|5)/))].content.*~
+    given: $.paths.*.*.responses[?(@property.match(/^(4|5)/))]
     then:
-      function: enumeration
-      functionOptions:
-        values:
-          - application/problem+json
+      - field: content
+        function: truthy
+      - field: content.application/problem+json
+        function: truthy
 
   entur-rfc-9457-body-title:
     message: "Error responses MUST have property 'title'."


### PR DESCRIPTION
…the case of an empty (or completely missing) content object.

closes: https://github.com/entur/api-guidelines/issues/29