### PR TITLE
fix: API-435: Removed linting rule "entur-headers-no-x-headers". 

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -338,15 +338,6 @@ rules:
 
 
   # Header naming conventions
-  entur-headers-no-x-headers:
-    message: "HTTP headers SHOULD NOT have an 'X-' prefix. Invalid name: \"{{value}}\"."
-    severity: warn
-    given: "$..parameters[?(@.in == 'header')].name"
-    then:
-      function: pattern
-      functionOptions:
-        notMatch: ^(x|X)-
-
   entur-headers-hyphenated-pascal-case:
     message: "HTTP header names MUST be in Hyphenated-Pascal-Case. Invalid name: \"{{value}}\"."
     severity: error

--- a/guidelines.md
+++ b/guidelines.md
@@ -208,7 +208,7 @@ Example:
 
 ### 5.5 HTTP Headers
 - :ballot_box_with_check: HTTP headers **MUST** use Hyphenated-Pascal-Case format (e.g., `Content-Type`, `Accept-Language`)
-- :white_check_mark: HTTP headers **SHOULD NOT** include the 'X-' prefix, following RFC 6648
+- :eyes: HTTP headers **SHOULD NOT** include the 'X-' prefix, following RFC 6648. Entur headers should have the prefix "Entur-". API:s are expected to use the prefix "Entur-" for custom headers by 2028.
 
 ## 6. Advanced Design Patterns
 <!-- More complex design patterns -->


### PR DESCRIPTION
Updated guidelines to show that this is reviewed manually.