### PR TITLE
fix: ETU-70915: Turn off rule "info-contact"

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -42,6 +42,7 @@ rules:
         notMatch: "/\\bapi\\b/i"
 
   info-description: error
+  info-contact: off
 
   # HTTP Methods
   entur-operation-standard-methods:


### PR DESCRIPTION
So that missing info.contact in spec does not produce warning.