### PR TITLE
fix: Disable example validity rules for required ruleset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,34 @@ jobs:
             cat $annotations
             cat $markdown >> $GITHUB_STEP_SUMMARY
           fi
+
+  # This invalid spec should still pass validate, since it has no critical errors
+  validate-reference-spec-with-errors:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Spectral
+        run: npm install -g @stoplight/spectral-cli
+      - name: Lint OpenAPI
+        shell: bash
+        run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+        
+          annotations=$(mktemp)
+          markdown=$(mktemp)
+          spectral lint ./specs/valid-reference-spec-with-errors.json --ruleset ".spectral-required.yml" --show-documentation-url -F hint -f github-actions -o.github-actions "$annotations" -f markdown -o.markdown="$markdown" && rc=$? || rc=$?
+
+          #Return code 2 means that spectral command failed to run (not linting errors), so fail workflow.
+          if [ "$rc" -eq 2 ]; then
+            echo "::error::Spectral execution error (exit code $rc)."
+            exit $rc
+          fi
+
+          if [ "$rc" -eq 1 ]; then
+            echo "::error::There were linting errors when there should not be (exit code $rc)."
+            exit $rc
+          fi

--- a/.spectral-required.yml
+++ b/.spectral-required.yml
@@ -6,6 +6,9 @@ extends: [spectral:oas]
 
 rules:
   no-$ref-siblings: "off"
+  # These generate too many false positives
+  oas3-valid-media-example: "off"
+  oas3-valid-schema-example: "off"
 
   # -------------------------------------------------------------------------
   # 2.3 Authentication and authorization

--- a/specs/valid-reference-spec-with-errors.json
+++ b/specs/valid-reference-spec-with-errors.json
@@ -11,8 +11,9 @@
       "email": "support@entur.no"
     },
     "x-entur-metadata": {
-      "owner": "team-Api",
-      "audience": "public"
+      "id": "items",
+      "owner": "team-api",
+      "audience": "open"
     }
   },
 


### PR DESCRIPTION
This rule proves to cause too many false positives, for example here: https://github.com/entur/mummu/pull/340. False positive in the sense that violations of these rules do not actually cause the developer-portal to crash. Zudoku renders invalid schema examples no problem. So the linter should handle those rules.